### PR TITLE
fix: 🐛 Fixing random bugs.

### DIFF
--- a/src/contentType.ts
+++ b/src/contentType.ts
@@ -15,13 +15,16 @@ export const DEFAULT_MIME_TYPE = 'text/html'
  * The order is important on this one.
  */
 const tests: Array<(input: testInput) => testOutput> = [
+  // svg
+  async ({ bytes }): testOutput => /^(<\?xml[^>]+>)?[^<^\w]+<svg/ig.test(
+    new TextDecoder().decode(bytes.slice(0, 64)))
+    ? 'image/svg+xml'
+    : undefined,
   // testing file-type from buffer
   async ({ bytes }): testOutput => (await fileTypeFromBuffer(bytes))?.mime,
   // testing file-type from path
   // ts-expect-error because the type definitions are misleading
   async ({ path }): testOutput => mime.lookup(path) || undefined,
-  // svg
-  async ({ bytes }): testOutput => new TextDecoder().decode(bytes.slice(0, 4)) === '<svg' ? 'image/svg+xml' : undefined,
   // default
   async (): Promise<string> => DEFAULT_MIME_TYPE
 ]

--- a/src/heliaFetch.ts
+++ b/src/heliaFetch.ts
@@ -28,7 +28,7 @@ export class HeliaFetch {
   private fs!: UnixFS
   private readonly delegatedRoutingApi: string
   private readonly log: debug.Debugger
-  private readonly PARSE_PATH_REGEX = /^\/(?<namespace>ip[fn]s)\/(?<address>[^/$]+)(?<relativePath>[^$]*)/
+  private readonly PARSE_PATH_REGEX = /^\/(?<namespace>ip[fn]s)\/(?<address>[^/$]+)(?<relativePath>[^$^?]*)/
   private readonly rootFilePatterns: string[]
   public node!: Helia
   public ready: Promise<void>


### PR DESCRIPTION
In this PR:

- `svg` is hard to identify as most libs are unable to do it properly.
- `query` params were not handled correctly.