### PR TITLE
feat: re-enable path queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ $ docker run -it -p 8080:8080 -e DEBUG="helia-http-gateway" helia
 | `DEBUG` | Debug level | `''`|
 | `PORT` | Port to listen on | `8080` |
 | `HOST` | Host to listen on | `0.0.0.0` |
+| `USE_SUBDOMAINS` | Whether to use [origin isolation](https://docs.ipfs.tech/how-to/gateway-best-practices/#use-subdomain-gateway-resolution-for-origin-isolation) | `false` |
 | `METRICS` | Whether to enable prometheus metrics. Any value other than 'true' will disable metrics. | `true` |
 | `USE_BITSWAP` | Use bitswap to fetch content from IPFS | `true` |
 | `USE_TRUSTLESS_GATEWAYS` | Whether to fetch content from trustless-gateways or not | `true` |

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,8 @@ export const HOST = process.env.HOST ?? '0.0.0.0'
 
 export const DEBUG = process.env.DEBUG ?? ''
 
+export const USE_SUBDOMAINS = process.env.USE_SUBDOMAINS === 'true'
+
 /**
  * If set to any value other than 'true', we will disable prometheus metrics.
  *

--- a/src/heliaServer.ts
+++ b/src/heliaServer.ts
@@ -1,5 +1,6 @@
-import { type FastifyReply, type FastifyRequest } from 'fastify'
+import { type FastifyReply, type FastifyRequest, type RouteGenericInterface } from 'fastify'
 import { CID } from 'multiformats'
+import { USE_SUBDOMAINS } from './constants.js'
 import { DEFAULT_MIME_TYPE, parseContentType } from './contentType.js'
 import { getCustomHelia } from './getCustomHelia.js'
 import { HeliaFetch } from './heliaFetch.js'
@@ -7,15 +8,27 @@ import type debug from 'debug'
 
 const HELIA_RELEASE_INFO_API = (version: string): string => `https://api.github.com/repos/ipfs/helia/git/ref/tags/helia-v${version}`
 
-export interface RouteEntry {
+export interface RouteEntry<T extends RouteGenericInterface = RouteGenericInterface> {
   path: string
   type: 'GET' | 'POST'
-  handler: (request: FastifyRequest, reply: FastifyReply) => Promise<void>
+  handler: (request: FastifyRequest<T>, reply: FastifyReply) => Promise<void>
 }
 
-interface RouteHandler {
-  request: FastifyRequest
+interface RouteHandler<T extends RouteGenericInterface = RouteGenericInterface> {
+  request: FastifyRequest<T>
   reply: FastifyReply
+}
+
+interface EntryParams {
+  ns: string
+  address: string
+  '*': string
+}
+
+interface ParsedEntryParams {
+  address: string
+  namespace: string
+  relativePath: string
 }
 
 export class HeliaServer {
@@ -47,10 +60,17 @@ export class HeliaServer {
     console.log('Helia Started!')
     this.routes = [
       {
-        path: '/:ns(ipfs|ipns)/*',
+        // without this non-wildcard postfixed path, the '/*' route will match first.
+        path: '/:ns(ipfs|ipns)/:address', // ipns/dnsLink or ipfs/cid
         type: 'GET',
-        handler: async (request, reply): Promise<void> => this.redirectToSubdomainGW({ request, reply })
-      }, {
+        handler: async (request, reply): Promise<void> => this.handleEntry({ request, reply })
+      },
+      {
+        path: '/:ns(ipfs|ipns)/:address/*', // ipns/dnsLink/relativePath or ipfs/cid/relativePath
+        type: 'GET',
+        handler: async (request, reply): Promise<void> => this.handleEntry({ request, reply })
+      },
+      {
         path: '/api/v0/version',
         type: 'POST',
         handler: async (request, reply): Promise<void> => this.heliaVersion({ request, reply })
@@ -71,6 +91,9 @@ export class HeliaServer {
         path: '/',
         type: 'GET',
         handler: async (request, reply): Promise<void> => {
+          if (USE_SUBDOMAINS && request.hostname.split('.').length > 1) {
+            return this.fetch({ request, reply })
+          }
           await reply.code(200).send('try /ipfs/<cid> or /ipns/<name>')
         }
       }
@@ -80,13 +103,17 @@ export class HeliaServer {
   /**
    * Redirects to the subdomain gateway.
    */
-  private async redirectToSubdomainGW ({ request, reply }: RouteHandler): Promise<void> {
-    const { namespace, address, relativePath } = this.heliaFetch.parsePath(request.url)
+  private async handleEntry ({ request, reply }: RouteHandler): Promise<void> {
+    if (!USE_SUBDOMAINS) {
+      return this.fetchWithoutSubdomain({ request, reply })
+    }
+    const { ns: namespace, address, '*': relativePath } = request.params as EntryParams
+    // this.heliaFetch.parsePath(request.url)
     let cidv1Address: string | null = null
     if (this.HAS_UPPERCASE_REGEX.test(address)) {
       cidv1Address = CID.parse(address).toV1().toString()
     }
-    const finalUrl = `//${cidv1Address ?? address}.${namespace}.${request.hostname}${relativePath}`
+    const finalUrl = `//${cidv1Address ?? address}.${namespace}.${request.hostname}${relativePath ?? ''}`
     this.log('Redirecting to final URL:', finalUrl)
     await reply.redirect(finalUrl)
   }
@@ -103,30 +130,45 @@ export class HeliaServer {
     return result.groups as { address: string, namespace: string }
   }
 
+  async fetchWithoutSubdomain ({ request, reply }: RouteHandler): Promise<void> {
+    const { ns: namespace, address, '*': relativePath } = request.params as EntryParams
+    try {
+      await this.isReady
+      await this._fetch({ request, reply, address, namespace, relativePath })
+    } catch (error) {
+      this.log('Error requesting content from helia:', error)
+      await reply.code(500).send(error)
+    }
+  }
+
+  async _fetch ({ reply, address, namespace, relativePath }: RouteHandler & ParsedEntryParams): Promise<void> {
+    this.log('Fetching from Helia:', { address, namespace, relativePath })
+    let type: string | undefined
+    // raw response is needed to respond with the correct content type.
+    for await (const chunk of await this.heliaFetch.fetch({ address, namespace, relativePath })) {
+      if (type === undefined) {
+        type = await parseContentType({ bytes: chunk, path: relativePath })
+        // this needs to happen first.
+        reply.raw.writeHead(200, {
+          'Content-Type': type ?? DEFAULT_MIME_TYPE,
+          'Cache-Control': 'public, max-age=31536000, immutable'
+        })
+      }
+      reply.raw.write(Buffer.from(chunk))
+    }
+    reply.raw.end()
+  }
+
   /**
-   * Fetches a path, which basically queries delegated routing API and then fetches the path from helia.
+   * Fetches a content for a subdomain, which basically queries delegated routing API and then fetches the path from helia.
    */
   async fetch ({ request, reply }: RouteHandler): Promise<void> {
     try {
       await this.isReady
       this.log('Requesting content from helia:', request.url)
-      let type: string | undefined
       const { address, namespace } = this.parseHostParts(request.hostname)
       const { url: relativePath } = request
-      this.log('Fetching from Helia:', { address, namespace, relativePath })
-      // raw response is needed to respond with the correct content type.
-      for await (const chunk of await this.heliaFetch.fetch({ address, namespace, relativePath })) {
-        if (type === undefined) {
-          type = await parseContentType({ bytes: chunk, path: relativePath })
-          // this needs to happen first.
-          reply.raw.writeHead(200, {
-            'Content-Type': type ?? DEFAULT_MIME_TYPE,
-            'Cache-Control': 'public, max-age=31536000, immutable'
-          })
-        }
-        reply.raw.write(Buffer.from(chunk))
-      }
-      reply.raw.end()
+      await this._fetch({ request, reply, address, namespace, relativePath })
     } catch (error) {
       this.log('Error requesting content from helia:', error)
       await reply.code(500).send(error)


### PR DESCRIPTION
- feat: re-enable path support and set to default

This change makes requests to http://localhost:port/ipns/<path> and http://localhost:port/ipfs/<path> work without redirecting to subdomains. This unblocks functionality for use in plprobelab/tiros without changes to tiros.

This also disables subdomains (and origin isolation) by default, which isn't great. We should re-enable this in the future, but it's not a priority right now.
