### PR TITLE
fix: silence max listeners exceeded warning

### DIFF
--- a/src/heliaServer.ts
+++ b/src/heliaServer.ts
@@ -1,3 +1,4 @@
+import { setMaxListeners } from 'node:events'
 import { type FastifyReply, type FastifyRequest, type RouteGenericInterface } from 'fastify'
 import { CID } from 'multiformats'
 import { USE_SUBDOMAINS, RESOLVE_REDIRECTS } from './constants.js'
@@ -150,6 +151,7 @@ export class HeliaServer {
 
   async fetchWithoutSubdomain ({ request, reply }: RouteHandler): Promise<void> {
     const opController = new AbortController()
+    setMaxListeners(Infinity, opController.signal)
     request.raw.on('close', () => {
       if (request.raw.aborted) {
         this.log('Request aborted by client')
@@ -196,6 +198,7 @@ export class HeliaServer {
    */
   async fetch ({ request, reply }: RouteHandler): Promise<void> {
     const opController = new AbortController()
+    setMaxListeners(Infinity, opController.signal)
     request.raw.on('close', () => {
       if (request.raw.aborted) {
         this.log('Request aborted by client')


### PR DESCRIPTION
Each request can kick of a lot of abortable work so the abort signal created will have a lot of listeners attached to it.

This is expected, but node will print a warning message that people can mistake for an error so increase the number of listeners allowed to silence the warning.