### PR TITLE
fix: redirect to proper encoded dnslink subdomain

### DIFF
--- a/src/dns-link-labels.ts
+++ b/src/dns-link-labels.ts
@@ -1,13 +1,35 @@
+import { CID } from 'multiformats/cid'
+
 /**
  * For dnslinks see https://specs.ipfs.tech/http-gateways/subdomain-gateway/#host-request-header
  * DNSLink names include . which means they must be inlined into a single DNS label to provide unique origin and work with wildcard TLS certificates.
  */
 
+// DNS label can have up to 63 characters, consisting of alphanumeric
+// characters or hyphens -, but it must not start or end with a hyphen.
+const dnsLabelRegex = /^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$/
+
 /**
- * We can receive either a peerId string or dnsLink label string here. PeerId strings do not have dots or dashes.
+ * We can receive either IPNS Name string or DNSLink label string here.
+ * IPNS Names do not have dots or dashes.
  */
-export function isDnsLabel (label: string): boolean {
-  return ['-', '.'].some((char) => label.includes(char))
+export function isValidDnsLabel (label: string): boolean {
+  // If string is not a valid IPNS Name (CID)
+  // then we assume it may be a valid DNSLabel.
+  try {
+    CID.parse(label)
+    return false
+  } catch {
+    return dnsLabelRegex.test(label)
+  }
+}
+
+/**
+ * Checks if label looks like inlined DNSLink.
+ * (https://specs.ipfs.tech/http-gateways/subdomain-gateway/#host-request-header)
+ */
+export function isInlinedDnsLink (label: string): boolean {
+  return isValidDnsLabel(label) && label.includes('-') && !label.includes('.')
 }
 
 /**
@@ -18,7 +40,7 @@ export function isDnsLabel (label: string): boolean {
  * @example en-wikipedia--on--ipfs-org.ipns.example.net -> example.net/ipns/en.wikipedia-on-ipfs.org
  */
 export function dnsLinkLabelDecoder (linkLabel: string): string {
-  return linkLabel.replace(/--/g, '-').replace(/-/g, '.')
+  return linkLabel.replace(/--/g, '%').replace(/-/g, '.').replace(/%/g, '-')
 }
 
 /**
@@ -29,5 +51,5 @@ export function dnsLinkLabelDecoder (linkLabel: string): string {
  * @example example.net/ipns/en.wikipedia-on-ipfs.org → Host: en-wikipedia--on--ipfs-org.ipns.example.net
  */
 export function dnsLinkLabelEncoder (linkLabel: string): string {
-  return linkLabel.replace(/\./g, '-').replace(/-/g, '--')
+  return linkLabel.replace(/-/g, '--').replace(/\./g, '-')
 }

--- a/src/heliaServer.ts
+++ b/src/heliaServer.ts
@@ -3,6 +3,7 @@ import { createVerifiedFetch, type VerifiedFetch } from '@helia/verified-fetch'
 import { type FastifyReply, type FastifyRequest, type RouteGenericInterface } from 'fastify'
 import { USE_SUBDOMAINS } from './constants.js'
 import { contentTypeParser } from './content-type-parser.js'
+import { dnsLinkLabelEncoder, isInlinedDnsLink } from './dns-link-labels.js'
 import { getCustomHelia } from './getCustomHelia.js'
 import { getIpnsAddressDetails } from './ipns-address-utils.js'
 import type { ComponentLogger, Logger } from '@libp2p/interface'
@@ -152,8 +153,12 @@ export class HeliaServer {
       // }
       // finalUrl += encodeURIComponent(`?${new URLSearchParams(request.query).toString()}`)
     }
+    let encodedDnsLink = address
+    if (!isInlinedDnsLink(address)) {
+      encodedDnsLink = dnsLinkLabelEncoder(address)
+    }
 
-    const finalUrl = `//${cidv1Address ?? address}.${namespace}.${request.hostname}/${relativePath ?? ''}`
+    const finalUrl = `//${cidv1Address ?? encodedDnsLink}.${namespace}.${request.hostname}/${relativePath ?? ''}`
     this.log('redirecting to final URL:', finalUrl)
     await reply
       .headers({


### PR DESCRIPTION
## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

## Description

redirects `localhost:8080/ipns/some.domain.with.dots` to `some-domain-with-dots.ipns.localhost:8080` when subdomain use is enabled

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
