### PR TITLE
fix: abort signal when request stream closed

### DIFF
--- a/debugging/until-death.sh
+++ b/debugging/until-death.sh
@@ -30,7 +30,7 @@ start_gateway() {
 start_gateway & process_pid=$!
 
 ensure_gateway_running() {
-  npx wait-on "tcp:$PORT" -t 1000 || exit 1
+  npx wait-on "tcp:$PORT" -t 5000 || exit 1
 }
 
 


### PR DESCRIPTION
- chore: make until-death script wait longer for gateway
- fix: abort signal when request stream is closed

## Title

<!---
The title of the PR will be the commit message of the merge commit, so please make sure it is descriptive enough.
We utilize the Conventional Commits specification for our commit messages. See <https://www.conventionalcommits.org/en/v1.0.0/#specification> for more information.
The commit tag types can be of one of the following: feat, fix, deps, refactor, chore, docs. See <https://github.com/ipfs/helia/blob/main/.github/workflows/main.yml#L184-L192>
The title must also be fewer than 72 characters long or it will fail the Semantic PR check. See <https://github.com/ipfs/helia/blob/main/.github/workflows/semantic-pull-request.yml>
--->

fix: abort signal when request stream closed

## Description

<!--
Please write a summary of your changes and why you made them.
Please include any relevant issues in here, for example:
Related https://github.com/ipfs/helia/issues/ABCD.
Fixes https://github.com/ipfs/helia/issues/XYZ.
-->

Detailed description of this fix is in https://github.com/ipfs/helia-http-gateway/issues/18#issuecomment-2024211790

## Notes & open questions

<!--
Any notes, remarks or open questions you have to make about the PR which don't need to go into the final commit message.
-->

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works



