### PR TITLE
fix: increase number of event listeners on opcontroller signal

### DIFF
--- a/src/helia-server.ts
+++ b/src/helia-server.ts
@@ -92,6 +92,7 @@ export class HeliaServer {
         type: 'GET',
         handler: async (request, reply): Promise<void> => {
           const signal = AbortSignal.timeout(1000)
+          setMaxListeners(Infinity, signal)
           try {
             // echo "hello world" | npx kubo add --cid-version 1 -Q --inline
             // inline CID is bafkqaddimvwgy3zao5xxe3debi


### PR DESCRIPTION
This signal gets listened to a lot so increase the number of event listeners allowed to prevent spurious warnings appearing in the logs.

## Change checklist

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
