### PR TITLE
fix: pass routers to helia

### DIFF
--- a/src/get-custom-helia.ts
+++ b/src/get-custom-helia.ts
@@ -33,18 +33,19 @@ export async function getCustomHelia (): Promise<Helia> {
     datastore = new LevelDatastore(FILE_DATASTORE_PATH)
   }
 
+  const routers: HeliaInit['routers'] = []
+  if (USE_DELEGATED_ROUTING) {
+    routers.push(delegatedHTTPRouting(DELEGATED_ROUTING_V1_HOST))
+  }
+
   if (USE_LIBP2P || USE_BITSWAP) {
     return createHelia({
       libp2p: await getCustomLibp2p({ datastore }),
       blockstore,
       datastore,
-      blockBrokers
+      blockBrokers,
+      routers
     })
-  }
-
-  const routers: HeliaInit['routers'] = []
-  if (USE_DELEGATED_ROUTING) {
-    routers.push(delegatedHTTPRouting(DELEGATED_ROUTING_V1_HOST))
   }
 
   return createHeliaHTTP({


### PR DESCRIPTION
Helia with libp2p can use delegated http routers so pass these in to the factory function if configured.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
