### PR TITLE
fix: follow verified-fetch redirects when subdomains are disabled

### DIFF
--- a/src/helia-http-gateway.ts
+++ b/src/helia-http-gateway.ts
@@ -87,7 +87,10 @@ export function httpGateway (opts: HeliaHTTPGatewayOptions): RouteOptions[] {
       url
     })
 
-    const resp = await opts.fetch(url, { signal, redirect: 'manual' })
+    // if subdomains are disabled, have @helia/verified-fetch follow redirects
+    // internally, otherwise let the client making the request do it
+    const resp = await opts.fetch(url, { signal, redirect: USE_SUBDOMAINS ? 'manual' : 'follow' })
+
     await convertVerifiedFetchResponseToFastifyReply(resp, reply)
   }
 


### PR DESCRIPTION
Pass `redirect: 'follow'` to `@helia/verified-fetch` when subdomain support is enabled, otherwise we send a 301 with no `Location` header.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
