### PR TITLE
fix: use fs stores by default in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,12 @@ EXPOSE 8080
 
 HEALTHCHECK --interval=12s --timeout=12s --start-period=10s CMD node dist/src/healthcheck.js
 
+# use level datastore by default
+ENV FILE_DATASTORE_PATH=/data/ipfs/datastore
+
+# use filesystem blockstore by default
+ENV FILE_BLOCKSTORE_PATH=/data/ipfs/blockstore
+
 # Use tini to handle signals properly, see https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
 ENTRYPOINT ["/usr/bin/tini", "-p", "SIGKILL", "--"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,13 @@ ENV FILE_DATASTORE_PATH=/data/ipfs/datastore
 # use filesystem blockstore by default
 ENV FILE_BLOCKSTORE_PATH=/data/ipfs/blockstore
 
+# enable metrics by default
+ENV METRICS=true
+
+# redirect ipfs/ipns paths to subdomains to prevent cookie theft by websites
+# loaded via the gateway
+ENV SUB_DOMAINS=true
+
 # Use tini to handle signals properly, see https://github.com/nodejs/docker-node/blob/main/docs/BestPractices.md#handling-kernel-signals
 ENTRYPOINT ["/usr/bin/tini", "-p", "SIGKILL", "--"]
 


### PR DESCRIPTION
This is to better align with Kubo's behaviour and also stops the containers running out of memory really quickly since in-memory stores aren't really meant for production use.

Also turns on metrics by default and explicitly enables sub domains.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
