### PR TITLE
fix: change default Graphana port

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -12,7 +12,7 @@ From inside this directory, you can run the following command to start up a graf
 docker compose -f docker-compose.yml up -d
 ```
 
-Then visit <http://localhost:3000/d/helia-http-gateway-default/helia-http-gateway-default-dashboard?orgId=1&refresh=5s> and login with the default credentials (admin:admin). The prometheus datasource and the dashboard should be automatically set up.
+Then visit <http://localhost:9191/d/helia-http-gateway-default/helia-http-gateway-default-dashboard?orgId=1&refresh=5s> and login with the default credentials (admin:admin). The prometheus datasource and the dashboard should be automatically set up.
 
 If you want to generate some metrics quickly, you can run `npm run debug:until-death` and you should start seeing metrics in the dashboard for the results of querying the gateway for the websites listed by <https://probelab.io/websites/>
 

--- a/config/docker-compose.yml
+++ b/config/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   grafana:
     image: grafana/grafana
     ports:
-      - 3000:3000
+      - 9191:3000
     volumes:
       - ./grafana/datasources:/etc/grafana/provisioning/datasources
       - ./grafana/dashboard.yaml:/etc/grafana/provisioning/dashboards/main.yaml


### PR DESCRIPTION
The default port of `3000` conflicts with the Chrome devtools protocol port when using tiros.

## Change checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
