### PR TITLE
chore: allow attaching a debugger to debug runs

### DIFF
--- a/debugging/until-death.sh
+++ b/debugging/until-death.sh
@@ -68,7 +68,7 @@ start_gateway() {
   fi
   echo "starting gateway..."
   # npx clinic doctor --open=false -- node dist/src/index.js &
-  (node --trace-warnings dist/src/index.js) &
+  (node --trace-warnings --inspect dist/src/index.js) &
   process_id=$!
   # echo "process id: $!"
   npx wait-on "tcp:$HTTP_PORT" -t 10000 || {


### PR DESCRIPTION
Starts node with the `--inspect` flag to allow attaching a debugger.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
