### PR TITLE
feat: add `USE_DHT_ROUTING` env var to turn DHT on and off

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ $ npm start
 | `ECHO_HEADERS`              | A debug flag to indicate whether you want to output request and response headers                                                               | `false`                                                                                                                 |
 | `USE_DELEGATED_ROUTING`     | Whether to use the delegated routing v1 API                                                                                                    | `true`                                                                                                                  |
 | `DELEGATED_ROUTING_V1_HOST` | Hostname to use for delegated routing v1                                                                                                       | `https://delegated-ipfs.dev`                                                                                            |
+| `USE_DHT_ROUTING`           | Whether to use @libp2p/kad-dht for routing when libp2p is enabled                                                                              | `true`                                                                                                                  |
 
 <!--
 TODO: currently broken when used in docker, but they work when running locally (you can cache datastore and blockstore locally to speed things up if you want)

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,13 @@ export const FILE_BLOCKSTORE_PATH = process.env.FILE_BLOCKSTORE_PATH ?? null
 export const USE_DELEGATED_ROUTING = process.env.USE_DELEGATED_ROUTING !== 'false'
 
 /**
+ * Whether to use the DHT for routing
+ *
+ * @default true
+ */
+export const USE_DHT_ROUTING = process.env.USE_DHT_ROUTING !== 'false'
+
+/**
  * If not set, we will default delegated routing to `https://delegated-ipfs.dev`
  */
 export const DELEGATED_ROUTING_V1_HOST = process.env.DELEGATED_ROUTING_V1_HOST ?? 'https://delegated-ipfs.dev'


### PR DESCRIPTION
To use just HTTP Delegated routing:

- `USE_DHT_ROUTING=false`
- `USE_DELEGATED_ROUTING=true`

To use just DHT routing:

- `USE_DHT_ROUTING=true`
- `USE_DELEGATED_ROUTING=false`

To use both (the default):

- `USE_DHT_ROUTING=true`
- `USE_DELEGATED_ROUTING=true`

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
