### PR TITLE
fix: default to fs stores when debugging

### DIFF
--- a/debugging/until-death.sh
+++ b/debugging/until-death.sh
@@ -10,6 +10,8 @@ fi
 export DEBUG=${DEBUG:-"helia-http-gateway,helia-http-gateway:server,helia-http-gateway:*:helia-fetch"}
 export HTTP_PORT=${HTTP_PORT:-8080}
 export RPC_PORT=${RPC_PORT:-5001}
+export FILE_DATASTORE_PATH=datastore
+export FILE_BLOCKSTORE_PATH=blockstore
 EXIT_CODE=0
 
 cleanup_until_death_called=false


### PR DESCRIPTION
Memory stores are only really meant for testing, default to using fs stores when debugging as otherwise it can look like you have a memory leak.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
