### PR TITLE
fix: reuse helia logger instead of creating a new one

### DIFF
--- a/src/healthcheck.ts
+++ b/src/healthcheck.ts
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 import { HOST, RPC_PORT } from './constants.js'
-import { logger } from './logger.js'
-
-const log = logger.forComponent('healthcheck')
 
 /**
- * This healthcheck script is used to check if the server is running and healthy.
+ * This healthcheck script is used to check if the server is running and healthy
  */
-const rootReq = await fetch(`http://${HOST}:${RPC_PORT}/api/v0/http-gateway-healthcheck`, { method: 'GET' })
+const rootReq = await fetch(`http://${HOST}:${RPC_PORT}/api/v0/http-gateway-healthcheck`, {
+  method: 'GET'
+})
 const status = rootReq.status
 
-log(`Healthcheck status: ${status}`)
 process.exit(status === 200 ? 0 : 1)

--- a/src/helia-http-gateway.ts
+++ b/src/helia-http-gateway.ts
@@ -3,7 +3,6 @@ import { dnsLinkLabelEncoder, isInlinedDnsLink } from './dns-link-labels.js'
 import { getFullUrlFromFastifyRequest, getRequestAwareSignal } from './helia-server.js'
 import { getIpnsAddressDetails } from './ipns-address-utils.js'
 import type { VerifiedFetch } from '@helia/verified-fetch'
-import type { ComponentLogger } from '@libp2p/interface'
 import type { FastifyReply, FastifyRequest, RouteOptions } from 'fastify'
 import type { Helia } from 'helia'
 
@@ -14,13 +13,12 @@ interface EntryParams {
 }
 
 export interface HeliaHTTPGatewayOptions {
-  logger: ComponentLogger
   helia: Helia
   fetch: VerifiedFetch
 }
 
 export function httpGateway (opts: HeliaHTTPGatewayOptions): RouteOptions[] {
-  const log = opts.logger.forComponent('http-gateway')
+  const log = opts.helia.logger.forComponent('http-gateway')
 
   /**
    * Redirects to the subdomain gateway.

--- a/src/helia-rpc-api.ts
+++ b/src/helia-rpc-api.ts
@@ -1,20 +1,18 @@
 import { GC_TIMEOUT_MS, HEALTHCHECK_TIMEOUT_MS } from './constants.js'
 import { getRequestAwareSignal } from './helia-server.js'
 import type { VerifiedFetch } from '@helia/verified-fetch'
-import type { ComponentLogger } from '@libp2p/interface'
 import type { FastifyReply, FastifyRequest, RouteOptions } from 'fastify'
 import type { Helia } from 'helia'
 
 const HELIA_RELEASE_INFO_API = (version: string): string => `https://api.github.com/repos/ipfs/helia/git/ref/tags/helia-v${version}`
 
 export interface HeliaRPCAPIOptions {
-  logger: ComponentLogger
   helia: Helia
   fetch: VerifiedFetch
 }
 
 export function rpcApi (opts: HeliaRPCAPIOptions): RouteOptions[] {
-  const log = opts.logger.forComponent('rpc-api')
+  const log = opts.helia.logger.forComponent('rpc-api')
   let heliaVersionInfo: { Version: string, Commit: string } | undefined
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,23 +166,19 @@ import { contentTypeParser } from './content-type-parser.js'
 import { getCustomHelia } from './get-custom-helia.js'
 import { httpGateway } from './helia-http-gateway.js'
 import { rpcApi } from './helia-rpc-api.js'
-import { logger } from './logger.js'
-
-const log = logger.forComponent('index')
 
 const helia = await getCustomHelia()
 const fetch = await createVerifiedFetch(helia, { contentTypeParser })
+const log = helia.logger.forComponent('index')
 
 const [rpcApiServer, httpGatewayServer] = await Promise.all([
   createServer('rpc-api', rpcApi({
-    logger,
     helia,
     fetch
   }), {
     metrics: false
   }),
   createServer('http-gateway', httpGateway({
-    logger,
     helia,
     fetch
   }), {

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,3 +1,0 @@
-import { prefixLogger } from '@libp2p/logger'
-
-export const logger = prefixLogger('helia-http-gateway')


### PR DESCRIPTION
Helia makes a logger available for use so use it instead of creating another one.  It prefixes log lines for us which makes component log names more intuitive.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
