### PR TITLE
fix: cancel stream reader on request abort

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
     "libp2p": "^1.3.1",
     "multiformats": "^13.1.0",
     "pino-pretty": "^11.0.0",
-    "private-ip": "^3.0.2"
+    "private-ip": "^3.0.2",
+    "race-signal": "^1.0.2"
   },
   "devDependencies": {
     "@playwright/test": "^1.43.0",


### PR DESCRIPTION
We need to cancel the reader on request abort, otherwise we leak resources.

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
