### PR TITLE
fix: remove singularity from smoke test

### DIFF
--- a/e2e-tests/smoketest.spec.ts
+++ b/e2e-tests/smoketest.spec.ts
@@ -19,7 +19,7 @@ const pages = [
   'probelab.io',
   'protocol.ai',
   'research.protocol.ai',
-  'singularity.storage',
+  // 'singularity.storage', // broken as of 09-07-2024
   'specs.ipfs.tech',
   // 'strn.network', // redirects to saturn.tech
   'saturn.tech',


### PR DESCRIPTION
Singularity's dnslink config is broken

## Change checklist

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation if necessary (this includes comments as well)
- [ ] I have added tests that prove my fix is effective or that my feature works
