### PR TITLE
chore: update upload-artifact action to v4

### DIFF
--- a/.github/workflows/gateway-conformance.yml
+++ b/.github/workflows/gateway-conformance.yml
@@ -110,13 +110,13 @@ jobs:
         run: cat output.md >> $GITHUB_STEP_SUMMARY
       - name: Upload HTML report
         if: failure() || success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gateway-conformance.html
           path: output.html
       - name: Upload JSON report
         if: failure() || success()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: gateway-conformance.json
           path: output.json

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -42,7 +42,7 @@ jobs:
       run: npm run test:e2e
       env:
         METRICS: false
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report


### PR DESCRIPTION
v3 is no longer supported as per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/